### PR TITLE
Support runtime events

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Hopefully that will get all of the necessary dependencies so you can run `dune b
 To use eio-console right now, it only supports monitoring a single eventring that you must specify. First, you have to run some program with eventring enabled. The executables in the `test` directory can be used for this (or any OCaml program that you can compile!):
 
 ```
-OCAML_EVENTRING_START=1 _build/default/test/fib.exe 2 50
+OCAML_RUNTIME_EVENTS_START=1 _build/default/test/fib.exe 2 50
 ```
 
 This will run the program and there should be a `<pid>.eventring` file in the directory that you ran the program from. You can then run

--- a/ec.opam
+++ b/ec.opam
@@ -37,6 +37,8 @@ build: [
 ]
 dev-repo: "git+https://github.com/patricoferris/eio-console.git"
 pin-depends: [
+  # Supporting Runtime_events
+  [ "ocamlfind.1.9.3" "git+https://github.com/patricoferris/ocamlfind#a8e5777c1605d64b3b570545352ba272074f4df1" ]
   # PRs merged for bigarray-compat but no release
   [ "multipart_form.0.4.0" "git+https://github.com/dinosaure/multipart_form#943d9afcb67cb5960c3f063626085ec2c4584789" ]
   [ "multipart_form-lwt.0.4.0" "git+https://github.com/dinosaure/multipart_form#943d9afcb67cb5960c3f063626085ec2c4584789" ]

--- a/ec.opam.template
+++ b/ec.opam.template
@@ -1,4 +1,6 @@
 pin-depends: [
+  # Supporting Runtime_events
+  [ "ocamlfind.1.9.3" "git+https://github.com/patricoferris/ocamlfind#a8e5777c1605d64b3b570545352ba272074f4df1" ]
   # PRs merged for bigarray-compat but no release
   [ "multipart_form.0.4.0" "git+https://github.com/dinosaure/multipart_form#943d9afcb67cb5960c3f063626085ec2c4584789" ]
   [ "multipart_form-lwt.0.4.0" "git+https://github.com/dinosaure/multipart_form#943d9afcb67cb5960c3f063626085ec2c4584789" ]

--- a/src/server/dune
+++ b/src/server/dune
@@ -1,6 +1,6 @@
 (executable
  (name main)
- (libraries dream lwt.unix ezjsonm ec.ev))
+ (libraries dream lwt.unix ezjsonm ec.ev runtime_events))
 
 (rule
  (targets index.ml)

--- a/src/server/main.ml
+++ b/src/server/main.ml
@@ -19,13 +19,13 @@ let forget client_id =
 let handle_client pid client =
   let open Lwt.Syntax in
   let _client_id = track client in
-  let+ () = Er.start_trace_record client pid in
+  let+ () = Rev.start_trace_record client pid in
   ()
 
 let () =
   let pid = 
     match String.split_on_char '.' Sys.argv.(1) with
-    | pid :: [ "eventring" ] -> print_endline pid; int_of_string pid
+    | pid :: [ "events" ] -> print_endline pid; int_of_string pid
     | _ -> failwith "Bad eventring file"
   in
   Dream.run

--- a/src/server/rev.ml
+++ b/src/server/rev.ml
@@ -1,4 +1,4 @@
-open Eventring
+open Runtime_events
 
 let tracing = Atomic.make true
 


### PR DESCRIPTION
This PR updates the code to take into account the renaming of `Eventring` to `Runtime_events`, and also the move from the standard library to otherlibs (see the pinned `ocamlfind` in the opam file).